### PR TITLE
fix(json-api): normalizeResource can now complete on undefined attributes

### DIFF
--- a/packages/json-api/src/Response/Resource/normalizeResource.js
+++ b/packages/json-api/src/Response/Resource/normalizeResource.js
@@ -67,7 +67,10 @@ export default function normalizeResource(data) {
   const resource = Resource.create(
     data.id,
     data.type,
-    Object.assign(data.attributes, getResourcesFromData(data)),
+    {
+      ...data.attributes,
+      ...getResourcesFromData(data),
+    },
     null,
     data.meta || null,
   );


### PR DESCRIPTION
Response could fail on `data.attributes` being undefined; `Object.assign(undefined, <value>)`.

Changed to `{ ...data.attributes, ...<value> }` to prevent error from occuring